### PR TITLE
fix node version to 14

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16]
+        node: [14]
 
     steps:
       - name: Checkout 🛎


### PR DESCRIPTION
各CI毎に設定がまちまちだったため、verselのランタイムに合わせて14に固定する。
