### PR TITLE
serve the public dir in storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,12 @@
 import '../src/styles/tailwind.css'
+import * as NextImage from 'next/image'
+
+const OriginalNextImage = NextImage.default
+
+Object.defineProperty(NextImage, 'default', {
+  configurable: true,
+  value: (props) => <OriginalNextImage {...props} unoptimized />,
+})
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "format": "yarn format:js",
     "format:js": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json,css}'",
     "test": "jest",
-    "storybook": "start-storybook -p 6006",
-    "build-storybook": "yarn build:path && build-storybook",
+    "storybook": "start-storybook -p 6006 -s ./public",
+    "build-storybook": "yarn build:path && build-storybook -s ./public",
     "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
     "dedupe": "npx yarn-deduplicate --strategy=fewer && yarn install --force",
     "lhci": "lhci autorun"

--- a/src/test/factories/blocks/imageFactory.ts
+++ b/src/test/factories/blocks/imageFactory.ts
@@ -11,7 +11,7 @@ export const imageFactory = Factory.define<BlockObject<'image'>>(() => ({
     caption: [],
     type: 'external',
     external: {
-      url: 'https://images.unsplash.com/photo-1602345553478-740db58ab250?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1357&q=80',
+      url: '/test-image.jpeg',
     },
   },
   has_children: false,


### PR DESCRIPTION
next/imageを利用する場合、画像の最適化のためのサーバーが `/_next-` のパスで起動することになる。
これはそのままではstorybookで利用できないため、最適化を無視するようにする。

ref: https://storybook.js.org/blog/get-started-with-storybook-and-next-js/
