### PR TITLE
add eslint plugin import access

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "unused-imports"],
+  "plugins": ["@typescript-eslint", "unused-imports", "import-access"],
   "extends": [
     "next",
     "next/core-web-vitals",
@@ -34,7 +34,8 @@
           "caseInsensitive": true
         }
       }
-    ]
+    ],
+    "import-access/jsdoc": ["error"]
   },
   "parserOptions": {
     "project": "./tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-config-next": "*",
     "eslint-config-prettier": "*",
     "eslint-plugin-import": "*",
+    "eslint-plugin-import-access": "*",
     "eslint-plugin-storybook": "*",
     "eslint-plugin-unused-imports": "*",
     "fishery": "*",

--- a/src/lib/ntn/client.ts
+++ b/src/lib/ntn/client.ts
@@ -3,6 +3,9 @@ import { ClientOptions } from '@notionhq/client/build/src/Client'
 
 import { PageObject, BlockObject } from './type'
 
+/**
+ * @package
+ */
 export class NotionClient {
   client: Client
 

--- a/src/lib/ntn/defaultBlockSchema.tsx
+++ b/src/lib/ntn/defaultBlockSchema.tsx
@@ -2,6 +2,9 @@ import { BlockRenderRules } from './type'
 
 const defaultMessage = (type: string) => `not supported block type: ${type}`
 
+/**
+ * @package
+ */
 export const defaultBlockSchema: BlockRenderRules = {
   audio: (block) => <div>{defaultMessage(block.type)}</div>,
   bookmark: (block) => <div>{defaultMessage(block.type)}</div>,

--- a/src/lib/ntn/type.ts
+++ b/src/lib/ntn/type.ts
@@ -49,9 +49,6 @@ export type BuildBlockParser = (rules: BlockParseRules) => BlockParser
 
 export type RenderBlocks = (blocks: BlockObject[]) => ReactElement[]
 
-/**
- * @private
- */
 export interface BlockViewProps<T> {
   block: BlockObject<T>
   renderBlocks?: RenderBlocks

--- a/src/lib/ntn/type.ts
+++ b/src/lib/ntn/type.ts
@@ -4,6 +4,9 @@ import { ReactElement } from 'react'
 type ElementType<T> = T extends (infer U)[] ? U : never
 type MatchType<T, U, V = never> = T extends U ? T : V
 
+/**
+ * @package
+ */
 export type PageObject = MatchType<
   ElementType<Awaited<ReturnType<Client['databases']['query']>>['results']>,
   {
@@ -11,6 +14,9 @@ export type PageObject = MatchType<
   }
 >
 
+/**
+ * @package
+ */
 export type BlockObject<T = unknown> = MatchType<
   ElementType<
     Awaited<ReturnType<Client['blocks']['children']['list']>>['results']
@@ -20,6 +26,9 @@ export type BlockObject<T = unknown> = MatchType<
   children?: BlockObject[]
 }
 
+/**
+ * @package
+ */
 export type RichTextObject = ElementType<
   MatchType<
     ElementType<
@@ -29,6 +38,9 @@ export type RichTextObject = ElementType<
   >['paragraph']['rich_text']
 >
 
+/**
+ * @package
+ */
 export type BlockRenderRules = {
   [key in BlockObject['type']]: (
     block: BlockObject<key>,
@@ -36,19 +48,35 @@ export type BlockRenderRules = {
   ) => ReactElement
 }
 
+/**
+ * @package
+ */
 export type BlockParseRules = {
   [key in BlockObject['type']]?: (
     block: BlockObject<key>,
   ) => Promise<BlockObject>
 }
+
+/**
+ * @package
+ */
 export interface BlockParser {
   parse: (blockObjects: BlockObject[]) => Promise<BlockObject[]>
 }
 
+/**
+ * @package
+ */
 export type BuildBlockParser = (rules: BlockParseRules) => BlockParser
 
+/**
+ * @package
+ */
 export type RenderBlocks = (blocks: BlockObject[]) => ReactElement[]
 
+/**
+ * @package
+ */
 export interface BlockViewProps<T> {
   block: BlockObject<T>
   renderBlocks?: RenderBlocks

--- a/src/lib/ntn/type.ts
+++ b/src/lib/ntn/type.ts
@@ -49,6 +49,9 @@ export type BuildBlockParser = (rules: BlockParseRules) => BlockParser
 
 export type RenderBlocks = (blocks: BlockObject[]) => ReactElement[]
 
+/**
+ * @private
+ */
 export interface BlockViewProps<T> {
   block: BlockObject<T>
   renderBlocks?: RenderBlocks

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,11 @@ import React from 'react'
 import { IndexPage } from 'src/components/Pages/IndexPage'
 import { Layout } from 'src/components/Pages/Layout'
 import { NotionClient, LogLevel } from '~/src/lib/ntn'
+import { BlockViewProps } from '~/src/lib/ntn/type'
+
+const hoge: BlockViewProps<"paragraph"> = {
+
+}
 
 type Props = {
   articles: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,11 +4,6 @@ import React from 'react'
 import { IndexPage } from 'src/components/Pages/IndexPage'
 import { Layout } from 'src/components/Pages/Layout'
 import { NotionClient, LogLevel } from '~/src/lib/ntn'
-import { BlockViewProps } from '~/src/lib/ntn/type'
-
-const hoge: BlockViewProps<"paragraph"> = {
-
-}
 
 type Props = {
   articles: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,12 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "plugins": [
+      {
+        "name": "eslint-plugin-import-access"
+      }
+    ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3102,12 +3102,12 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@^5.3.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.17.0.tgz#303ba1d766d715c3225a31845b54941889e52f6c"
-  integrity sha512-U4sM5z0/ymSYqQT6I7lz8l0ZZ9zrya5VIwrwAP5WOJVabVtVsIpTMxPQe+D3qLyePT+VlETUTO2nA1+PufPx9Q==
+"@typescript-eslint/experimental-utils@^5.3.0", "@typescript-eslint/experimental-utils@^5.9.1":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.20.0.tgz#7ed593bed40424d9c4160f3f86c3f6f56d6c87af"
+  integrity sha512-w5qtx2Wr9x13Dp/3ic9iGOGmVXK5gMwyc8rwVgZU46K9WTjPZSyPvdER9Ycy+B5lNHvoz+z2muWhUvlTpQeu+g==
   dependencies:
-    "@typescript-eslint/utils" "5.17.0"
+    "@typescript-eslint/utils" "5.20.0"
 
 "@typescript-eslint/parser@*", "@typescript-eslint/parser@5.10.1":
   version "5.10.1"
@@ -3127,14 +3127,6 @@
     "@typescript-eslint/types" "5.10.1"
     "@typescript-eslint/visitor-keys" "5.10.1"
 
-"@typescript-eslint/scope-manager@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.17.0.tgz#4cea7d0e0bc0e79eb60cad431c89120987c3f952"
-  integrity sha512-062iCYQF/doQ9T2WWfJohQKKN1zmmXVfAcS3xaiialiw8ZUGy05Em6QVNYJGO34/sU1a7a+90U3dUNfqUDHr3w==
-  dependencies:
-    "@typescript-eslint/types" "5.17.0"
-    "@typescript-eslint/visitor-keys" "5.17.0"
-
 "@typescript-eslint/scope-manager@5.18.0":
   version "5.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.18.0.tgz#a7d7b49b973ba8cebf2a3710eefd457ef2fb5505"
@@ -3142,6 +3134,14 @@
   dependencies:
     "@typescript-eslint/types" "5.18.0"
     "@typescript-eslint/visitor-keys" "5.18.0"
+
+"@typescript-eslint/scope-manager@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz#79c7fb8598d2942e45b3c881ced95319818c7980"
+  integrity sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==
+  dependencies:
+    "@typescript-eslint/types" "5.20.0"
+    "@typescript-eslint/visitor-keys" "5.20.0"
 
 "@typescript-eslint/type-utils@5.18.0":
   version "5.18.0"
@@ -3157,15 +3157,15 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.10.1.tgz#dca9bd4cb8c067fc85304a31f38ec4766ba2d1ea"
   integrity sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==
 
-"@typescript-eslint/types@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.17.0.tgz#861ec9e669ffa2aa9b873dd4d28d9b1ce26d216f"
-  integrity sha512-AgQ4rWzmCxOZLioFEjlzOI3Ch8giDWx8aUDxyNw9iOeCvD3GEYAB7dxWGQy4T/rPVe8iPmu73jPHuaSqcjKvxw==
-
 "@typescript-eslint/types@5.18.0":
   version "5.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.18.0.tgz#4f0425d85fdb863071680983853c59a62ce9566e"
   integrity sha512-bhV1+XjM+9bHMTmXi46p1Led5NP6iqQcsOxgx7fvk6gGiV48c6IynY0apQb7693twJDsXiVzNXTflhplmaiJaw==
+
+"@typescript-eslint/types@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.20.0.tgz#fa39c3c2aa786568302318f1cb51fcf64258c20c"
+  integrity sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==
 
 "@typescript-eslint/typescript-estree@5.10.1":
   version "5.10.1"
@@ -3174,19 +3174,6 @@
   dependencies:
     "@typescript-eslint/types" "5.10.1"
     "@typescript-eslint/visitor-keys" "5.10.1"
-    debug "^4.3.2"
-    globby "^11.0.4"
-    is-glob "^4.0.3"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/typescript-estree@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.17.0.tgz#a7cba7dfc8f9cc2ac78c18584e684507df4f2488"
-  integrity sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==
-  dependencies:
-    "@typescript-eslint/types" "5.17.0"
-    "@typescript-eslint/visitor-keys" "5.17.0"
     debug "^4.3.2"
     globby "^11.0.4"
     is-glob "^4.0.3"
@@ -3206,17 +3193,18 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.17.0.tgz#549a9e1d491c6ccd3624bc3c1b098f5cfb45f306"
-  integrity sha512-DVvndq1QoxQH+hFv+MUQHrrWZ7gQ5KcJzyjhzcqB1Y2Xes1UQQkTRPUfRpqhS8mhTWsSb2+iyvDW1Lef5DD7vA==
+"@typescript-eslint/typescript-estree@5.20.0", "@typescript-eslint/typescript-estree@^5.9.1":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz#ab73686ab18c8781bbf249c9459a55dc9417d6b0"
+  integrity sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==
   dependencies:
-    "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.17.0"
-    "@typescript-eslint/types" "5.17.0"
-    "@typescript-eslint/typescript-estree" "5.17.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
+    "@typescript-eslint/types" "5.20.0"
+    "@typescript-eslint/visitor-keys" "5.20.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/utils@5.18.0":
   version "5.18.0"
@@ -3230,6 +3218,18 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/utils@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.20.0.tgz#b8e959ed11eca1b2d5414e12417fd94cae3517a5"
+  integrity sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.20.0"
+    "@typescript-eslint/types" "5.20.0"
+    "@typescript-eslint/typescript-estree" "5.20.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/visitor-keys@5.10.1":
   version "5.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz#29102de692f59d7d34ecc457ed59ab5fc558010b"
@@ -3238,20 +3238,20 @@
     "@typescript-eslint/types" "5.10.1"
     eslint-visitor-keys "^3.0.0"
 
-"@typescript-eslint/visitor-keys@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.17.0.tgz#52daae45c61b0211b4c81b53a71841911e479128"
-  integrity sha512-6K/zlc4OfCagUu7Am/BD5k8PSWQOgh34Nrv9Rxe2tBzlJ7uOeJ/h7ugCGDCeEZHT6k2CJBhbk9IsbkPI0uvUkA==
-  dependencies:
-    "@typescript-eslint/types" "5.17.0"
-    eslint-visitor-keys "^3.0.0"
-
 "@typescript-eslint/visitor-keys@5.18.0":
   version "5.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.18.0.tgz#c7c07709823804171d569017f3b031ced7253e60"
   integrity sha512-Hf+t+dJsjAKpKSkg3EHvbtEpFFb/1CiOHnvI8bjHgOD4/wAw3gKrA0i94LrbekypiZVanJu3McWJg7rWDMzRTg==
   dependencies:
     "@typescript-eslint/types" "5.18.0"
+    eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz#70236b5c6b67fbaf8b2f58bf3414b76c1e826c2a"
+  integrity sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==
+  dependencies:
+    "@typescript-eslint/types" "5.20.0"
     eslint-visitor-keys "^3.0.0"
 
 "@webassemblyjs/ast@1.9.0":
@@ -6015,6 +6015,15 @@ eslint-module-utils@^2.7.0:
   dependencies:
     debug "^3.2.7"
     find-up "^2.1.0"
+
+eslint-plugin-import-access@*:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import-access/-/eslint-plugin-import-access-1.0.1.tgz#47ccf8baa89b5ecd1c355823926c520c064108ed"
+  integrity sha512-u9vNNDh7RTVUoPMsLepDt0fII5d8+k84/igZ41Hn4vqYMfktYAiwF4Y0pYGYDcZ6Ln7IB/VRaB6YUfRgFx8+Aw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^5.9.1"
+    "@typescript-eslint/typescript-estree" "^5.9.1"
+    tsutils "^3.21.0"
 
 eslint-plugin-import@*, eslint-plugin-import@2.25.2:
   version "2.25.2"


### PR DESCRIPTION
- yarn add -D "eslint-plugin-import-access@*"
- installation eslint-plugin-import-access
- add package-private annotation

ref: https://zenn.dev/uhyo/articles/eslint-plugin-import-access
importできなくなる例: https://zenn.dev/uhyo/articles/eslint-plugin-import-access