### PR TITLE
add addon explicitly

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -11,6 +11,7 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
     '@storybook/addon-a11y',
+    '@storybook/addon-actions',
     {
       name: '@storybook/addon-postcss',
       options: {


### PR DESCRIPTION
Resolves the problem of failed builds of storybook.
Errors that had occurred: https://github.com/MH4GF/log.mh4gf.dev/runs/6584246090?check_suite_focus=true

solution: https://github.com/storybookjs/storybook/issues/17996#issuecomment-1134810729
