### PR TITLE
enable to publish chromatic if dependabot

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,13 +2,10 @@ name: chromatic
 
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
 
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
     strategy:
       matrix:
         node-version: [14]


### PR DESCRIPTION
storybookのアップグレードによって動作しなくなるパターンがあるため、
dependabotのPRでもchromaticを有効化する
