### PR TITLE
fix baseUrl

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -4,5 +4,6 @@ declare namespace NodeJS {
     readonly NOTION_DATABASE_ID: string
     readonly NEXT_PUBLIC_GTM_ID: string
     readonly NEXT_PUBLIC_VERCEL_URL: string
+    readonly NEXT_PUBLIC_VERCEL_ALIAS_URL?: string
   }
 }

--- a/src/lib/axios/apiRoutesAxios.ts
+++ b/src/lib/axios/apiRoutesAxios.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 
-const protocol = process.env.NEXT_PUBLIC_VERCEL_URL === 'localhost:3000' ? 'http' : 'https'
+const hostUrl = process.env.NEXT_PUBLIC_VERCEL_ALIAS_URL || process.env.NEXT_PUBLIC_VERCEL_URL
+const protocol = hostUrl === 'localhost:3000' ? 'http' : 'https'
 const baseUrl = `${protocol}://${process.env.NEXT_PUBLIC_VERCEL_URL}`
 
 export const apiRoutesAxios = axios.create({ baseURL: baseUrl })


### PR DESCRIPTION
API RoutesにアクセスするためのaxiosインスタンスのbaseUrlで、 `NEXT_PUBLIC_VERCEL_ALIAS_URL` があればそれを優先して利用するようにします。

# background

クライアントサイドからAPI Routesで設定したAPIにリクエストするために、request originが必要です。
そのための解決策として、NEXT_PUBLIC_VERCEL_URLにはnext.jsアプリがホスティングされているURLが格納されており、preview環境等でも自動的にhostを切り替えることができていました。
しかしproduction環境の場合はホスティングされているURLではなくカスタムドメインをaliasとして貼ったURLにアクセスするため、リクエストしたURLとは別のURLになりCORSのエラーになってしまいます。

# solution

環境変数としてaliasのURLを追加し、それがあれば優先して利用するようにします。
取り急ぎProduction環境だけ設定しているため、他の環境ではフォールバックしてNEXT_PUBLIC_VERCEL_URLを参照しbaseUrlを確定することになります。

しかし、この場合設定したalias以外のURL(e.g. https://log-mh4gf-dev.vercel.app/)からアクセスするとエラーになってしまいますが、仕方ないと許容しています。

# another solutions

別の選択肢としてはgetServerSidePropsから参照可能な `req` オブジェクトからhostnameを取得し利用することが考えられ、このような実装で解決はできそうです。ref: https://github.com/jakeburden/next-absolute-url
これであれば環境差異を気にせずリクエストされたURLを利用することができます。
しかしこのプロジェクトではgetStaticPropsを利用したSSGなため、getServerSidePropsとの併用ができません。そのためこの手段は実現できませんでした。

もう一つの手段としてNext12から導入されたmiddlewareでreqオブジェクトが参照可能です。しかしコンポーネントまでpropsとして情報を渡すのはできなさそう？なため断念しました。もしかしたら可能かもしれません。
ref: https://github.com/vercel/next.js/discussions/21431