### PR TITLE
fix(build): disable release to sentry if not vercel

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,8 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 })
 
 const { withSentryConfig } = require('@sentry/nextjs')
-const sentryWebpackPluginOptions = {}
+const sentryWebpackPluginOptions = {
+  dryRun: process.env.RELEASE !== 'true',
+}
 
 module.exports = withBundleAnalyzer(withSentryConfig(nextConfig, sentryWebpackPluginOptions))

--- a/next.config.js
+++ b/next.config.js
@@ -16,8 +16,6 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 })
 
 const { withSentryConfig } = require('@sentry/nextjs')
-const sentryWebpackPluginOptions = {
-  silent: true,
-}
+const sentryWebpackPluginOptions = {}
 
 module.exports = withBundleAnalyzer(withSentryConfig(nextConfig, sentryWebpackPluginOptions))


### PR DESCRIPTION
Closes #318 
preview環境、production環境に `RELEASE` という環境変数を追加し、その環境変数がなければdryRunとみなしてreleaseを送信しないようにした。

```
❯ yarn vercel env add
yarn run v1.22.19
$ /Users/mh4gf/ghq/github.com/MH4GF/log.mh4gf.dev/node_modules/.bin/vercel env add
Vercel CLI 25.1.0
? What’s the name of the variable? RELEASE
? What’s the value of RELEASE? true
? Add RELEASE to which Environments (select multiple)? Production, Preview
✅  Added Environment Variable RELEASE to Project log-mh4gf-dev [600ms]
✨  Done in 17.29s.
```