### PR TITLE
fix(parseOGP): 不正なCSSが含まれるHTMLを読み込むとエラーになるため無視する

### DIFF
--- a/apps/blog/src/features/article/parseOGP/server/parseHTML.ts
+++ b/apps/blog/src/features/article/parseOGP/server/parseHTML.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { JSDOM } from 'jsdom'
+import { JSDOM, VirtualConsole } from 'jsdom'
 
 import type { OGPResult } from '../types'
 
@@ -23,13 +23,20 @@ const extractOGP = (head: HTMLHeadElement): OGPResult => {
   }
 }
 
+// 不正なCSSを読み込むとエラーが発生する。CSSはOGPに関係ないので無視する
+// ref: https://github.com/jsdom/jsdom/issues/2230
+const virtualConsole = new VirtualConsole()
+virtualConsole.on('error', () => {
+  console.warn('virtualConsole error')
+})
+
 export const parseHTML = async (url: string): Promise<OGPResult> => {
   const headers = { 'User-Agent': 'bot' }
   const res = await axios.get<string>(url, {
     headers,
     responseType: 'document',
   })
-  const dom = new JSDOM(res.data)
+  const dom = new JSDOM(res.data, { virtualConsole })
 
   return extractOGP(dom.window.document.head)
 }


### PR DESCRIPTION
CSSはOGPに関係ないので無視する
ref: https://github.com/jsdom/jsdom/issues/2230
